### PR TITLE
Use 2.X Solana crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,15 +3,15 @@ members = ["invoke", "test-program"]
 resolver = "2"
 
 [workspace.dependencies]
-solana-account-info = "3.0.0"
-solana-cpi = "3.0.0"
-solana-define-syscall = "3.0.0"
-solana-instruction = "3.0.0"
+solana-account-info = "2"
+solana-cpi = "2"
+solana-define-syscall = "2"
+solana-instruction = "2"
 solana-invoke = { path = "./invoke" }
-solana-msg = "3.0.0"
-solana-program-entrypoint = "3.1.0"
-solana-pubkey = "3.0.0"
+solana-msg = "2"
+solana-program-entrypoint = "2"
+solana-pubkey = "2"
 solana-sdk-ids = "2.0"
-solana-stable-layout = { version = "3.0.0" }
-solana-system-interface = { version = "2.0.0", features = ["bincode"] }
-solana-sysvar = "3.0.0"
+solana-stable-layout = { version = "2" }
+solana-system-interface = { version = "1", features = ["bincode"] }
+solana-sysvar = "2"

--- a/invoke/Cargo.toml
+++ b/invoke/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-invoke"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 authors = [
     "Cavey Cool <caveycool@gmail.com>",


### PR DESCRIPTION
Currently, Anchor uses Solana 2.x crates but this crate depends on 3.x crates and can't be used with it. Drop the versions to allow it to be integrated.