### PR TITLE
Support syscall stubs in non-bpf environments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4890,7 +4890,7 @@ dependencies = [
 
 [[package]]
 name = "solana-invoke"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "solana-account-info",
  "solana-cpi",
@@ -4900,6 +4900,7 @@ dependencies = [
  "solana-pubkey",
  "solana-stable-layout",
  "solana-system-interface",
+ "solana-sysvar",
 ]
 
 [[package]]

--- a/invoke/Cargo.toml
+++ b/invoke/Cargo.toml
@@ -17,6 +17,7 @@ solana-define-syscall.workspace = true
 solana-instruction = { workspace = true }
 solana-program-entrypoint = { workspace = true }
 solana-stable-layout = { workspace = true }
+solana-sysvar = { workspace = true }
 
 [dev-dependencies]
 solana-cpi = { workspace = true }

--- a/invoke/src/lib.rs
+++ b/invoke/src/lib.rs
@@ -39,35 +39,62 @@ pub fn invoke_signed(
     invoke_signed_unchecked(instruction, account_infos, signers_seeds)
 }
 
-#[cfg(target_os = "solana")]
-use solana_define_syscall::definitions::sol_invoke_signed_rust;
-
-#[cfg(not(target_os = "solana"))]
-unsafe fn sol_invoke_signed_rust(_: *const u8, _: *const u8, _: u64, _: *const u8, _: u64) -> u64 {
-    unimplemented!("only supported with `target_os = \"solana\"")
-}
-
 pub fn invoke_signed_unchecked(
     instruction: &Instruction,
     account_infos: &[AccountInfo],
     signers_seeds: &[&[&[u8]]],
 ) -> ProgramResult {
-    use stable_instruction_borrowed::StableInstructionBorrowed;
-    let stable = StableInstructionBorrowed::new(instruction);
-    let instruction_addr = stable.instruction_addr();
+    #[cfg(target_os = "solana")]
+    {
+        cpi::invoke_signed_unchecked(instruction, account_infos, signers_seeds)
+    }
 
-    let result = unsafe {
-        sol_invoke_signed_rust(
-            instruction_addr,
-            account_infos as *const _ as *const u8,
-            account_infos.len() as u64,
-            signers_seeds as *const _ as *const u8,
-            signers_seeds.len() as u64,
-        )
-    };
+    #[cfg(not(target_os = "solana"))]
+    solana_sysvar::program_stubs::sol_invoke_signed(instruction, account_infos, signers_seeds)
+}
 
-    match result {
-        solana_program_entrypoint::SUCCESS => Ok(()),
-        _ => Err(result.into()),
+pub mod cpi {
+    use super::stable_instruction_borrowed;
+    use solana_account_info::AccountInfo;
+    use solana_instruction::Instruction;
+    use solana_program_entrypoint::ProgramResult;
+
+    pub fn invoke_signed_unchecked(
+        instruction: &Instruction,
+        account_infos: &[AccountInfo],
+        signers_seeds: &[&[&[u8]]],
+    ) -> ProgramResult {
+        use stable_instruction_borrowed::StableInstructionBorrowed;
+        let stable = StableInstructionBorrowed::new(instruction);
+        let instruction_addr = stable.instruction_addr();
+
+        let result = unsafe {
+            sol_invoke_signed_rust(
+                instruction_addr,
+                account_infos as *const _ as *const u8,
+                account_infos.len() as u64,
+                signers_seeds as *const _ as *const u8,
+                signers_seeds.len() as u64,
+            )
+        };
+
+        match result {
+            solana_program_entrypoint::SUCCESS => Ok(()),
+            _ => Err(result.into()),
+        }
+    }
+
+    #[cfg(target_os = "solana")]
+    use solana_define_syscall::definitions::sol_invoke_signed_rust;
+
+    #[cfg(not(target_os = "solana"))]
+    unsafe fn sol_invoke_signed_rust(
+        _: *const u8,
+        _: *const u8,
+        _: u64,
+        _: *const u8,
+        _: u64,
+    ) -> u64 {
+        unimplemented!("only supported with `target_os = \"solana\"")
     }
 }


### PR DESCRIPTION
Add the ability to override `sol_invoke_signed` in non-bpf environments.

I have tried to follow the same pattern as the main solana client lib, reusing the stubs structs.

https://github.com/anza-xyz/solana-sdk/blob/449d97c0ed164611dae538e2ee91ca0caaaec515/program/src/program.rs#L85

Our usecase is (hongg)fuzzing an anchor program.
